### PR TITLE
Change download link to "latest release page"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ description: Powerful search for Windows
 avatar: /images/Logo.png
 
 # Link to downloads page
-downloads: https://github.com/dnGrep/dnGrep/releases
+downloads: https://github.com/dnGrep/dnGrep/releases/latest
 
 # Link to help page
 help: https://github.com/dnGrep/dnGrep/wiki


### PR DESCRIPTION
The artifacts expander is expanded on the "latest release" page by default, which is an improvement. And when clicking the site's download button I don't think most people are interested in historical versions, which the current URL shows.